### PR TITLE
Added support for Ubuntu 16.04.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 gemfile:
    - test/support/Gemfile
 rvm:
-  - 2.2.1
+  - 2.2.2
 script: bundle exec rake foodcritic

--- a/Berksfile
+++ b/Berksfile
@@ -2,6 +2,6 @@ source "https://supermarket.getchef.com"
 
 metadata
 
-cookbook 'build-essential', '~>2.0.6'
+cookbook 'build-essential', '~>7.0.3'
 cookbook 'python', '~>1.4.6'
-cookbook 'rsyslog', '~>1.12.2'
+cookbook 'rsyslog', '~> 5.1.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 UWSGI COOKBOOK CHANGELOG
 ========================
 
+1.2.0 (2017-01-10)
+------------------
+- Added Ubuntu 16.04 to Test Kitchen.
+- Bumped `rsyslog` cookbook version.
+- Bumped `build-essential` cookbook version.
+- Bumped `uwsgi` source version from 2.0.9 to 2.0.14.
+
 1.1.3 (2016-03-15)
 ------------------
 - Updated Travis configuration to support Ruby 2.2.1.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ allow flexible configuration.
 
 ## Supported Platforms
 
-Supported platforms:  Ubuntu Server 14.04.
+Supported platforms:  Ubuntu Server 14.04, 16.04
 
 Resources
 ---------
@@ -75,7 +75,7 @@ License & Authors
 - Author:: Sean M. Sullivan (<sean@pulselocker.com>)
 
 ```text
-Copyright:: 2014-2016 Pulselocker, Inc.
+Copyright:: 2014-2017 Pulselocker, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 #
 
 # uWSGI source
-default['uwsgi']['version'] = '2.0.9'
+default['uwsgi']['version'] = '2.0.14'
 default['uwsgi']['download_url'] = 'http://projects.unbit.it/downloads'
 default['uwsgi']['service'] = 'uwsgi-server'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@pulselocker.com'
 license          'Apache 2.0'
 description      'Installs/Configures uWSGI application server.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.1.3'
+version          '1.2.0'
 issues_url       'https://github.com/arktos65/uwsgi-cookbook/issues' if respond_to?(:issues_url)
 source_url       'https://github.com/arktos65/uwsgi-cookbook' if respond_to?(:source_url)
 


### PR DESCRIPTION
- Added Ubuntu 16.04 to Test Kitchen.
- Bumped `rsyslog` cookbook version.
- Bumped `build-essential` cookbook version.
- Bumped `uwsgi` source version from 2.0.9 to 2.0.14.